### PR TITLE
Fix fetch order data and leverage logging

### DIFF
--- a/src/modules/dataFetcher.js
+++ b/src/modules/dataFetcher.js
@@ -78,31 +78,17 @@ export async function fetchAccountBalance() {
  */
 export async function fetchRecentFills(symbol = SYMBOL) {
   // ccxt.fetchMyTrades는 최근 체결 내역(진입·청산 포함)을 보여줍니다.
-  // 여기서는 “positionSide”가 동일한 방향으로 두 번 체결된 이후,
-  // 청산되는 트레이드를 isClosed=true로 간주하는 단순 예시입니다.
+  // 본 봇에서는 체결 정보를 사용해 TP/SL 주문 체결 여부를 판단하므로
+  // orderId와 timestamp 등을 그대로 반환합니다.
   const trades = await exchange.fetchMyTrades(symbol);
-  const results = [];
 
-  // 단순화: 각 체결을 순회하면서 fee, side 구분이 필요하나
-  // 여기서는 'exitReason'을 'TAKE_PROFIT' / 'STOP_LOSS'로 채우지 않고
-  // 청산된 모든 체결을 isClosed=true로 반환합니다.
-  trades.forEach(trade => {
-    if (trade.side === 'sell' || trade.side === 'buy') {
-      // 진입 매매인지 청산 매매인지 구분하려면
-      // 세부 position 정보를 추가로 조회해야 하나,
-      // 간단히 모든 체결을 이전 미청산 상태 → 청산 상태로 가정
-      results.push({
-        tradeId:        trade.id,
-        exitPrice:      trade.price,
-        exitReason:     'FILLED',
-        pnl:            trade.cost - trade.fee,       // 단순 계산: cost(가격×수량) - 수수료
-        durationSeconds: 0,                            // duration은 별도로 추적 필요
-        isClosed:       true
-      });
-    }
-  });
-
-  return results;
+  return trades.map(trade => ({
+    id: trade.id,
+    orderId: trade.order,
+    timestamp: trade.timestamp,
+    price: trade.price,
+    side: trade.side
+  }));
 }
 
 export default {

--- a/src/modules/logger.js
+++ b/src/modules/logger.js
@@ -59,7 +59,7 @@ export async function initDb() {
  * @param {number} info.slPct
  * @returns {Promise<number>} insert된 trade ID
  */
-export async function logTradeOpen({ timestamp, symbol, side, entryPrice, entryQty, leverage, tpPct, slPct }) {
+export async function logTradeOpen({ timestamp, symbol, side, entryPrice, entryQty, entryLeverage, tpPct, slPct }) {
   const sql = `
     INSERT INTO trades
       (timestamp, symbol, side, entry_price, entry_qty, entry_leverage, tp_pct, sl_pct)
@@ -71,7 +71,7 @@ export async function logTradeOpen({ timestamp, symbol, side, entryPrice, entryQ
     side,
     entryPrice,
     entryQty,
-    leverage,
+    entryLeverage,
     tpPct,
     slPct
   ];

--- a/src/modules/orderManager.js
+++ b/src/modules/orderManager.js
@@ -78,10 +78,10 @@ export async function openPosition({ symbol, side, qty, entryPrice, leverage, tp
     }
   );
 
-  // 5) 손절 주문 (stop_market, reduceOnly)
+  // 5) 손절 주문 (STOP_MARKET, reduceOnly)
   const slOrder = await exchange.createOrder(
     symbol,
-    'stop_market',
+    'STOP_MARKET',
     side === 'LONG' ? 'sell' : 'buy',
     qty,
     undefined,


### PR DESCRIPTION
## Summary
- return proper fields for recent fills
- fix leverage parameter name in logger
- use correct `STOP_MARKET` order type

## Testing
- `node src/index.js` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_684009085ba08320aaa5fcd247ee2ab7